### PR TITLE
Basic functionality to create text and speech datasets

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,0 +1,174 @@
+import datasets
+from datasets import Dataset, Audio, Value
+import itertools
+from functools import partial
+
+def _ensure_list(x):
+    return x if isinstance(x, list) else [x]
+
+def _load_single_huggingface_dataset(load_dataset_params):
+    ds = datasets.load_dataset(**load_dataset_params)
+    if 'train' in ds or 'test' in ds:
+        raise ValueError(
+            "The dataset split should be specified in config, e.g. "
+            "'split: train' or 'split: train+test'. Config provided: "
+            f"{load_dataset_params}. Splits found: {list(ds.keys())}."
+        )
+    return ds
+
+def _combine_datasets_generator(left, right):
+    """
+    A generator that yields combined text and audio data from two sorted
+    datasets based on unique IDs. It expects 'left' and 'right' to be sorted
+    by 'id'.
+    """
+    def update_combined_entry(combined_entry, entry):
+        for key, value in entry.items():
+            if key == 'id':
+                continue
+            elif key.startswith('text_'):
+                combined_entry[key] = value
+            elif key == 'audio':
+                language_key = 'audio_' + entry['audio_language']
+                combined_entry.setdefault(language_key, []).append(value)
+                speaker_id_key = f'audio_{entry["audio_language"]}_speaker_id'
+                combined_entry.setdefault(
+                    speaker_id_key, []).append(entry['speaker_id'])
+        return combined_entry
+
+    # TODO: Work around the sorted() call, which requires everything in memory.
+    merged_datasets = sorted(itertools.chain(left, right), key=lambda x: x['id'])
+
+    current_id = None
+    combined_entry = {}
+    for entry in merged_datasets:
+        entry_id = entry['id']
+        if entry_id != current_id and current_id is not None:
+            yield combined_entry
+            combined_entry = {}
+        current_id = entry_id
+        combined_entry['id'] = entry_id
+        combined_entry = update_combined_entry(combined_entry, entry)
+
+    if combined_entry:
+        yield combined_entry
+
+def _load_huggingface_datasets(config):
+    """Retrieve all specified HuggingFace datasets and return as a list."""
+    loaded_datasets = []
+    if 'huggingface_load' not in config:
+        raise ValueError(
+            'There should be a `huggingface_load` entry in the dataset config, '
+            f'specifying which datasets to download. Got: {config}.'
+        )
+
+    load_list = config['huggingface_load']
+    for l in _ensure_list(load_list):
+        if 'join' in l:
+            if not isinstance(l['join'], list) or len(l['join']) != 2:
+                raise ValueError(
+                    'If a dataset join is specified, then there should be a '
+                    f'list of exactly two datasets to be joined. Got: {l}.'
+                )
+            left = _load_single_huggingface_dataset(l['join'][0])
+            right = _load_single_huggingface_dataset(l['join'][1])
+            ds = _combine_datasets_generator(left, right)
+        else:
+            ds = _load_single_huggingface_dataset(l)
+        loaded_datasets.append(ds)
+    return loaded_datasets
+
+def _matching_items(row, source_target_config):
+    """Find which items in a row match the config."""
+    matches = []
+    speaker_id_filter = source_target_config.get('speaker_id')
+    for language in _ensure_list(source_target_config['language']):
+        if source_target_config['type'] == 'text':
+            if row.get(f'text_{language}'):
+                matches.append([row[f'text_{language}'], language])
+        elif source_target_config['type'] == 'speech':
+            if row.get('audio_language') == language:
+                if speaker_id_filter and row['speaker_id'] != speaker_id_filter:
+                    continue
+                matches.append([row['audio'], language])
+            if f'audio_{language}' in row:
+                for audio_example, speaker_id in zip(
+                    row[f'audio_{language}'],
+                    row[f'audio_{language}_speaker_id']):
+                    if speaker_id_filter and speaker_id != speaker_id_filter:
+                        continue
+                    matches.append([audio_example, language])
+        else:
+            raise ValueError(
+                'Unknown source/target type. Should be one of '
+                f'"speech" or "text", got: {source_target_config}.'
+            )
+    return matches
+
+def _matching_pairs(row, dataset_config):
+    """Find all source/target pairs that match the configuration."""
+    source_items = _matching_items(row, dataset_config['source'])
+    target_items = _matching_items(row, dataset_config['target'])
+    for source in source_items:
+        for target in target_items:
+            yield {
+                'source': source[0], 'source_language': source[1],
+                'target': target[0], 'target_language': target[1]
+            }
+
+def _create_generator(config):
+    huggingface_datasets = _load_huggingface_datasets(config)
+    for ds in huggingface_datasets:
+        for row in ds:
+            for match in _matching_pairs(row, config):
+                yield {k: match[k] for k in ['source', 'target']}
+
+def create(config):
+    """
+    Create a dataset from the given configuration.
+
+    Args:
+      huggingface_load : Dict containing keyword arguments to HuggingFace
+          datasets.load_dataset(), or a list of dicts to load multiple
+          datasets.
+      source: Dict containing source specification, as below.
+      target: Dict containing target specification, as below.
+      shuffle: Whether to shuffle the data after loading (default False).
+
+    Source and target configuration:
+      language: Either an ISO 639-2 language code (e.g. 'eng', 'lug'),
+          or a list of codes.
+      type: 'text' or 'speech'.
+      recording_type: In the case of audio, 'studio', 'natural' or
+          'any' (default).
+      preprocessing: list of any functions that should be applied at
+          load time (done once, same output every epoch).
+      preprocessing_on_the_fly: list of any functions that should be applied
+          subsequently, on the fly (e.g. augmentation, for different output
+          every epoch).
+
+    Returns:
+      dataset: A datasets.Dataset object with attributes `source` and `target`.
+    """
+    # TODO: checks on configuration to make sure it's valid.
+    # TODO: make sample rate configurable.
+    
+    for language in [config[s]['language'] for s in ['source', 'target']]:
+        if ',' in language and isinstance(language, str):
+            raise ValueError(
+                'A list of languages has been specified in config as a string: '
+                f'{language}. Change to [{language}] to make it a list.')
+    
+    audio_feature = Audio(sampling_rate=16_000)
+    
+    features = datasets.Features({
+        'source': (Value('string') if config['source']['type'] == 'text'
+                   else audio_feature),
+        'target': (Value('string') if config['target']['type'] == 'text'
+                   else audio_feature),
+
+    })
+
+    generator_function = lambda: _create_generator(config)
+    return datasets.Dataset.from_generator(
+        generator_function, features=features)

--- a/dataset.py
+++ b/dataset.py
@@ -1,7 +1,5 @@
 import datasets
-from datasets import Dataset, Audio, Value
 import itertools
-from preprocessing import text_preprocessing
 
 def _ensure_list(x):
     return x if isinstance(x, list) else [x]
@@ -167,19 +165,23 @@ def create(config):
     """
     # TODO: checks on configuration to make sure it's valid.
     # TODO: make sample rate configurable.
-    
+   
+    # Multiple source or target languages can be specified in the yaml config
+    # e.g. with "language: [lug, ach]". An easy mistake is to write
+    # "language: lug, ach" instead , which gets converted to a string and not
+    # a list, so check for that and alert the user.
     for language in [config[s]['language'] for s in ['source', 'target']]:
         if ',' in language and isinstance(language, str):
             raise ValueError(
                 'A list of languages has been specified in config as a string: '
                 f'{language}. Change to [{language}] to make it a list.')
     
-    audio_feature = Audio(sampling_rate=16_000)
+    audio_feature = datasets.Audio(sampling_rate=16_000)
     
     features = datasets.Features({
-        'source': (Value('string') if config['source']['type'] == 'text'
+        'source': (datasets.Value('string') if config['source']['type'] == 'text'
                    else audio_feature),
-        'target': (Value('string') if config['target']['type'] == 'text'
+        'target': (datasets.Value('string') if config['target']['type'] == 'text'
                    else audio_feature),
 
     })

--- a/dataset_test.py
+++ b/dataset_test.py
@@ -1,0 +1,359 @@
+import unittest
+import dataset
+import soundfile
+import pandas as pd
+import datasets
+from datasets import Dataset, Audio
+import tempfile
+import os
+import numpy as np
+import yaml
+
+class DatasetTestCase(unittest.TestCase):
+    def assertNestedAlmostEqual(self, expected, actual, places=3):
+        """
+        Recursive function to compare nested data structures with support for
+        comparing floating point numbers using assertAlmostEqual and ignores
+        differences in base temporary path of file paths.
+        """
+        if isinstance(expected, (float, np.floating)):
+            self.assertAlmostEqual(expected, actual, places=places)
+        elif isinstance(expected, list):
+            self.assertEqual(len(expected), len(actual))
+            for exp, act in zip(expected, actual):
+                self.assertNestedAlmostEqual(exp, act, places=places)
+        elif isinstance(expected, dict):
+            self.assertEqual(set(expected.keys()), set(actual.keys()))
+            for key in expected:
+                if key == 'path':
+                  # Paths don't need to match
+                  pass
+                else:
+                    self.assertNestedAlmostEqual(expected[key], actual[key],
+                                                 places=places)
+        elif isinstance(expected, np.ndarray):
+            np.testing.assert_almost_equal(expected, actual, decimal=places)
+        else:
+            self.assertEqual(expected, actual)
+            
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.data_path = self.temp_dir.name
+
+        audio_path = f'{self.data_path}/audio'
+        if not os.path.exists(audio_path):
+            os.mkdir(audio_path)
+            
+        soundfile.write(
+          f'{audio_path}/lug1.wav', np.array([.1, .1, .1], np.float32), 16000)
+        soundfile.write(
+          f'{audio_path}/lug2.wav', np.array([.2, .2, .2], np.float32), 16000)
+        soundfile.write(
+          f'{audio_path}/lug1_studio.wav', np.array([.3, .3, .3], np.float32),
+          16000)
+        soundfile.write(
+          f'{audio_path}/lug2_studio.wav', np.array([.4, .4, .4], np.float32),
+          16000)
+        soundfile.write(
+          f'{audio_path}/eng1.wav', np.array([.5, .5, .5], np.float32), 16000)
+        soundfile.write(
+          f'{audio_path}/eng2.wav', np.array([.6, .6, .6], np.float32), 16000)
+        soundfile.write(
+          f'{audio_path}/eng3.wav', np.array([.7, .7, .7], np.float32), 16000)
+        soundfile.write(
+          f'{audio_path}/ach1.wav', np.array([.8, .8, .8], np.float32), 16000)
+        
+        translate_data_1 = {
+            'id': [1, 2, 3],
+            'text_lug': ['lug1', 'lug2', 'lug3'],
+            'text_ach': ['ach1', 'ach2', 'ach3'],
+            'text_eng': ['eng1', 'eng2', 'eng3'],
+        }
+
+        translate_data_2 = {
+            'id': [4, 5],
+            'text_lug': ['lug4', 'lug5'],
+            'text_eng': ['eng4', 'eng5'],
+        }
+        
+        translate_data_missing_value = {
+            'id': [1, 2, 3],
+            'text_lug': ['lug1', None, 'lug3'],
+            'text_ach': ['ach1', 'ach2', 'ach3'],
+            'text_eng': ['eng1', 'eng2', 'eng3'],
+        }
+
+        audio_metadata = {
+            'id': [1, 2, 1, 2, 1, 2, 3, 1],
+            'audio': [
+                f'{audio_path}/lug1.wav',
+                f'{audio_path}/lug2.wav',
+                f'{audio_path}/lug1_studio.wav',
+                f'{audio_path}/lug2_studio.wav',
+                f'{audio_path}/eng1.wav',
+                f'{audio_path}/eng2.wav',
+                f'{audio_path}/eng3.wav',
+                f'{audio_path}/ach1.wav',
+            ],
+            'text': [
+              'lug1', 'lug2', 'lug1', 'lug2', 'eng1', 'eng2', 'eng3', 'ach1'],
+            'audio_language': [
+              'lug', 'lug', 'lug', 'lug', 'eng', 'eng', 'eng', 'ach'],
+            'is_studio': [
+              False, False, True, True, False, False, False, False],
+            'speaker_id': [
+                'lug-001',
+                'lug-002',
+                'lug-studio-1',
+                'lug-studio-1',
+                'eng-001',
+                'eng-002',
+                'eng-001',
+                'ach-001'
+            ]
+        }
+
+        temp_csv_path = f'{self.data_path}/translation_dataset_1.csv'
+        pd.DataFrame(translate_data_1).to_csv(temp_csv_path, index=False)    
+
+        temp_csv_path = f'{self.data_path}/translation_dataset_2.csv'
+        pd.DataFrame(translate_data_2).to_csv(temp_csv_path, index=False)
+        
+        temp_csv_path = f'{self.data_path}/translation_missing_value.csv'
+        pd.DataFrame(translate_data_missing_value).to_csv(
+          temp_csv_path, index=False)
+
+        audio_dataset = Dataset.from_dict(audio_metadata).cast_column(
+          'audio', Audio(sampling_rate=16000))
+        audio_dataset.to_parquet(f'{self.data_path}/audio_mock.parquet')
+        
+    def tearDown(self):
+      self.temp_dir.cleanup()
+      
+
+    def test_text_to_speech_dataset(self):      
+      yaml_config = '''
+      huggingface_load:
+          join:
+            - path: parquet
+              data_files: PATH/audio_mock.parquet
+              split: train
+            - path: csv
+              data_files: PATH/translation_dataset_1.csv
+              split: train
+      source:
+          type: text
+          language: lug
+      target:
+          type: speech
+          language: lug
+          speaker_id: lug-studio-1
+      '''.replace('PATH', self.data_path)
+      config = yaml.safe_load(yaml_config)
+      ds = dataset.create(config)
+      
+      expected = [
+        {'source': 'lug1',
+         'target': {'path': None,
+                    'array': np.array([.3, .3, .3]),
+                    'sampling_rate': 16000}},
+        {'source': 'lug2',
+         'target': {'path': None,
+                    'array': np.array([.4, .4, .4]),
+                    'sampling_rate': 16000}},
+      ]
+      
+      self.assertNestedAlmostEqual(list(ds), expected)
+   
+        
+    def test_single_dataset(self):        
+        yaml_config = '''
+        huggingface_load:
+            path: csv
+            data_files: PATH/translation_dataset_1.csv
+            split: train
+        source:
+            type: text
+            language: lug
+        target:
+            type: text
+            language: eng
+        '''.replace('PATH', self.data_path)
+
+        config = yaml.safe_load(yaml_config)
+        ds = dataset.create(config)
+        
+        expected = [
+            {'source': 'lug1', 'target': 'eng1'},
+            {'source': 'lug2', 'target': 'eng2'},
+            {'source': 'lug3', 'target': 'eng3'}]
+
+        self.assertEquals(list(ds), expected)
+        
+    def test_translation_multiple_to_one(self):        
+        yaml_config = '''
+        huggingface_load:
+            path: csv
+            data_files: PATH/translation_dataset_1.csv
+            split: train
+        source:
+            type: text
+            language: [lug, ach]
+        target:
+            type: text
+            language: eng
+        '''.replace('PATH', self.data_path)
+
+        config = yaml.safe_load(yaml_config)
+        ds = dataset.create(config)
+        
+        expected = [
+            {'source': 'lug1', 'target': 'eng1'},
+            {'source': 'lug2', 'target': 'eng2'},
+            {'source': 'lug3', 'target': 'eng3'},
+            {'source': 'ach1', 'target': 'eng1'},
+            {'source': 'ach2', 'target': 'eng2'},
+            {'source': 'ach3', 'target': 'eng3'},
+        ]
+
+        self.assertCountEqual(list(ds), expected)
+
+    def test_two_datasets_concatenated(self):        
+        yaml_config = '''
+        huggingface_load:
+          - path: csv
+            data_files: PATH/translation_dataset_1.csv
+            split: train
+          - path: csv
+            data_files: PATH/translation_dataset_2.csv
+            split: train
+        source:
+            type: text
+            language: lug
+        target:
+            type: text
+            language: eng
+        '''.replace('PATH', self.data_path)
+
+        config = yaml.safe_load(yaml_config)
+        ds = dataset.create(config)
+        
+        expected = [
+            {'source': 'lug1', 'target': 'eng1'},
+            {'source': 'lug2', 'target': 'eng2'},
+            {'source': 'lug3', 'target': 'eng3'},
+            {'source': 'lug4', 'target': 'eng4'},
+            {'source': 'lug5', 'target': 'eng5'}
+        ]
+
+        self.assertEqual(list(ds), expected)
+
+    def test_missing_value(self):        
+        yaml_config = '''
+        huggingface_load:
+          - path: csv
+            data_files: PATH/translation_missing_value.csv
+            split: train
+          - path: csv
+            data_files: PATH/translation_dataset_2.csv
+            split: train
+        source:
+            type: text
+            language: lug
+        target:
+            type: text
+            language: eng
+        '''.replace('PATH', self.data_path)
+
+        config = yaml.safe_load(yaml_config)
+        ds = dataset.create(config)
+        
+        expected = [
+            {'source': 'lug1', 'target': 'eng1'},
+            {'source': 'lug3', 'target': 'eng3'},
+            {'source': 'lug4', 'target': 'eng4',},
+            {'source': 'lug5', 'target': 'eng5'}
+        ]
+
+        self.assertEqual(list(ds), expected)
+        
+    def test_join_speech_translation_dataset(self):
+      yaml_config = '''
+      huggingface_load:
+          join:
+            - path: parquet
+              data_files: PATH/audio_mock.parquet
+              split: train
+            - path: csv
+              data_files: PATH/translation_dataset_1.csv
+              split: train
+      source:
+          type: speech
+          language: lug
+      target:
+          type: text
+          language: eng
+      '''.replace('PATH', self.data_path)
+      config = yaml.safe_load(yaml_config)
+      ds = dataset.create(config)
+      
+      expected = [
+        {'source': {'path': None,
+                    'array': np.array([.1, .1, .1]),
+                    'sampling_rate': 16000},
+         'target': 'eng1'},
+        {'source': {'path': None,
+                    'array': np.array([.3, .3, .3]),
+                    'sampling_rate': 16000},
+         'target': 'eng1'},
+        {'source': {'path': None,
+                    'array': np.array([.2, .2, .2]),
+                    'sampling_rate': 16000},
+         'target': 'eng2'},
+        {'source': {'path': None,
+                    'array': np.array([.4, .4, .4]),
+                    'sampling_rate': 16000},
+         'target': 'eng2'}]
+      
+      self.assertNestedAlmostEqual(list(ds), expected)
+        
+    def test_speech_to_speech_dataset(self):
+      yaml_config = '''
+      huggingface_load:
+          join:
+            - path: parquet
+              data_files: PATH/audio_mock.parquet
+              split: train
+            - path: csv
+              data_files: PATH/translation_dataset_1.csv
+              split: train
+      source:
+          type: speech
+          language: lug
+      target:
+          type: speech
+          language: ach
+      '''.replace('PATH', self.data_path)
+      config = yaml.safe_load(yaml_config)
+      ds = dataset.create(config)
+      
+      expected = [
+        {'source': {'path': None,
+                    'array': np.array([.1, .1, .1]),
+                    'sampling_rate': 16000},
+         'target': {'path': None,
+                    'array': np.array([.8, .8, .8]),
+                    'sampling_rate': 16000}},
+        {'source': {'path': None,
+                    'array': np.array([.3, .3, .3]),
+                    'sampling_rate': 16000},
+         'target': {'path': None,
+                    'array': np.array([.8, .8, .8]),
+                    'sampling_rate': 16000}},
+      ]
+
+      self.assertNestedAlmostEqual(list(ds), expected)
+      
+if __name__ == '__main__':
+    unittest.main()
+

--- a/notebooks/Leb test.ipynb
+++ b/notebooks/Leb test.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cbed12e4-cf71-4d7b-9bfe-b4e3e57c17b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('..')\n",
+    "import dataset\n",
+    "import yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4660897f-5955-4584-bbec-22b89c20ab63",
+   "metadata": {},
+   "source": [
+    "## Example datasets from SALT format\n",
+    "\n",
+    "- Luganda and Acholi text to English text (multiple-to-one translation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "12e3e539-f3cf-43bc-9a6d-3fe7d279637c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'source': 'lug1', 'target': 'eng1'},\n",
+       " {'source': 'ach1', 'target': 'eng1'},\n",
+       " {'source': 'lug2', 'target': 'eng2'},\n",
+       " {'source': 'ach2', 'target': 'eng2'},\n",
+       " {'source': 'lug3', 'target': 'eng3'},\n",
+       " {'source': 'ach3', 'target': 'eng3'}]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "yaml_config = '''\n",
+    "huggingface_load:\n",
+    "  join: \n",
+    "      - path: jq/audio_mock_1\n",
+    "        split: train\n",
+    "      - path: jq/translate_mock_1\n",
+    "        split: train\n",
+    "source:\n",
+    "  type: text\n",
+    "  language: [lug, ach]\n",
+    "target:\n",
+    "  type: text\n",
+    "  language: eng\n",
+    "'''\n",
+    "\n",
+    "config = yaml.safe_load(yaml_config)\n",
+    "ds = dataset.create(config)\n",
+    "list(ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55754081-7441-4b69-94f4-bd757cc150fe",
+   "metadata": {},
+   "source": [
+    "- Luganda and Acholi audio to English text (speech translation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e2f8582f-12f9-4b0b-807e-5fc617e15b64",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'source': {'path': None,\n",
+       "   'array': array([0.09997559, 0.09997559, 0.09997559]),\n",
+       "   'sampling_rate': 16000},\n",
+       "  'target': 'eng1'},\n",
+       " {'source': {'path': None,\n",
+       "   'array': array([0.29998779, 0.29998779, 0.29998779]),\n",
+       "   'sampling_rate': 16000},\n",
+       "  'target': 'eng1'},\n",
+       " {'source': {'path': None,\n",
+       "   'array': array([0.79998779, 0.79998779, 0.79998779]),\n",
+       "   'sampling_rate': 16000},\n",
+       "  'target': 'eng1'},\n",
+       " {'source': {'path': None,\n",
+       "   'array': array([0.19998169, 0.19998169, 0.19998169]),\n",
+       "   'sampling_rate': 16000},\n",
+       "  'target': 'eng2'},\n",
+       " {'source': {'path': None,\n",
+       "   'array': array([0.3999939, 0.3999939, 0.3999939]),\n",
+       "   'sampling_rate': 16000},\n",
+       "  'target': 'eng2'}]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "yaml_config = '''\n",
+    "huggingface_load:\n",
+    "  join: \n",
+    "      - path: jq/audio_mock_1\n",
+    "        split: train\n",
+    "      - path: jq/translate_mock_1\n",
+    "        split: train\n",
+    "source:\n",
+    "  type: speech\n",
+    "  language: [lug, ach]\n",
+    "target:\n",
+    "  type: text\n",
+    "  language: eng\n",
+    "'''\n",
+    "\n",
+    "config = yaml.safe_load(yaml_config)\n",
+    "ds = dataset.create(config)\n",
+    "list(ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdf11ca7-548c-4303-8be7-e5f609beb4e3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This adds basic functionality to specify a dataset configuration in yaml format, and for that to be generated from SALT-formatted source data on HuggingFace.

Current configuation options:

- The `source` and `target` of the generated dataset can be either speech or text.
- The languages included in the source and target can be a single 3 digit ISO code, or a list.
- An audio dataset and translation dataset in SALT format can be joined based on phrase ID.

Usage examples are in notebooks/, and unit tests cover the main cases (mock datasets for many-to-one translation, ASR, speech translation, etc).

