### PR TITLE
Add logic for preprocessing operations

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,12 +1,14 @@
 import datasets
-from datasets import Dataset, Audio, Value
+from datasets import Dataset, Audio, Value, Features
 import itertools
-from preprocessing import text_preprocessing
+import text_preprocessing
+import functools
 
 def _ensure_list(x):
     return x if isinstance(x, list) else [x]
 
 def _load_single_huggingface_dataset(load_dataset_params):
+    # TODO: If single audio file, reformat to match joined audio+translate.
     ds = datasets.load_dataset(**load_dataset_params)
     if 'train' in ds or 'test' in ds:
         raise ValueError(
@@ -37,7 +39,8 @@ def _combine_datasets_generator(left, right):
         return combined_entry
 
     # TODO: Work around the sorted() call, which requires everything in memory.
-    merged_datasets = sorted(itertools.chain(left, right), key=lambda x: x['id'])
+    merged_datasets = sorted(
+        itertools.chain(left, right), key=lambda x: x['id'])
 
     current_id = None
     combined_entry = {}
@@ -86,21 +89,32 @@ def _matching_items(row, source_target_config):
         if source_target_config['type'] == 'text':
             if row.get(f'text_{language}'):
                 matches.append(
-                    {'value': row[f'text_{language}'], 'language': language})
+                    {'text': row[f'text_{language}'],
+                     'language': language,
+                     'origin_dataset': None, # TODO
+                    })
         elif source_target_config['type'] == 'speech':
             if row.get('audio_language') == language:
                 if speaker_id_filter and row['speaker_id'] != speaker_id_filter:
                     continue
                 matches.append(
-                    {'value': row['audio'], 'language': language})
+                    {'audio': row['audio'],
+                     'language': row['audio_language'],
+                     'speaker_id': row['speaker_id'],
+                     'is_studio': row['is_studio'],
+                    })
             if f'audio_{language}' in row:
                 for audio_example, speaker_id in zip(
                     row[f'audio_{language}'],
                     row[f'audio_{language}_speaker_id']):
                     if speaker_id_filter and speaker_id != speaker_id_filter:
                         continue
-                    matches.append(
-                        {'value': audio_example, 'language': language})
+                    matches.append({
+                        'audio': audio_example,
+                        'language': language,
+                        'speaker_id': speaker_id,
+                        'is_studio': None,  # TODO
+                    })
         else:
             raise ValueError(
                 'Unknown source/target type. Should be one of '
@@ -108,36 +122,94 @@ def _matching_items(row, source_target_config):
             )
     return matches
 
-def _matching_pairs(row,
-                    config,
-                    source_preprocess_fn,
-                    target_preprocess_fn):
+def _matching_pairs(row, config):
     """Find all source/target pairs that match the configuration."""
     source_items = _matching_items(row, config['source'])
     target_items = _matching_items(row, config['target'])
     
     for source in source_items:
-        source = source_preprocess_fn(source)
         for target in target_items:
-            target = target_preprocess_fn(target)
-            yield {
-                'source': source['value'],
-                'source_language': source['language'],
-                'target': target['value'],
-                'target_language': target['language'],
+            example = {
+                'source': source.get('text') or source.get('audio'),
+                'target': target.get('text') or target.get('audio'),
             }
+            
+            for k, v in source.items():
+                if k not in ['text', 'audio']:
+                    example['source_' + k] = v
+                    
+            for k, v in target.items():
+                if k not in ['text', 'audio']:
+                    example['target_' + k] = v
+
+            yield example
 
 def _create_generator(config):
-    source_preprocess_fn = lambda x: x
-    target_preprocess_fn = lambda x: x
+    '''Make a generator that yields examples according to dataset spec.'''    
     huggingface_datasets = _load_huggingface_datasets(config)
     for ds in huggingface_datasets:
         for row in ds:
-            for match in _matching_pairs(row, config,
-                                         source_preprocess_fn,
-                                         target_preprocess_fn):
-                yield {k: match[k] for k in ['source', 'target']}
+            for match in _matching_pairs(row, config):
+                yield match
 
+def _compose(functions):
+    def inner(arg):
+        for f in functions:
+            arg = f(arg)
+        return arg
+    return inner
+                 
+def _build_source_or_target_preprocess_function(config, source_or_target):
+    '''Compose the specified preprocessing ops into one function object.'''
+    preprocess_spec = config[source_or_target].get('preprocessing')
+    
+    # If nothing is specified, just return the identify function.
+    if not preprocess_spec:
+        return lambda x: x
+
+    functions = []
+    for f in preprocess_spec:
+        # The YAML for each preprocessing operation looks like either 
+        # "function_name" or {"function_name": kwargs} 
+        if isinstance(f, str):
+            function_name = f
+            kwargs = {}
+        else:
+            function_name = list(f.keys())[0]
+            kwargs = f[function_name]
+                
+        # Find the corresponding function definition    
+        if config[source_or_target]['type'] == 'text':
+            function = getattr(text_preprocessing, function_name)
+        else:
+            raise NotImplementedError() # TODO audio
+                    
+        functions.append(
+            functools.partial(function, src_or_tgt=source_or_target, **kwargs))
+                
+    preprocess_fn = _compose(functions)        
+    return preprocess_fn
+    
+def _keep_only_source_and_target(row):
+    result = {
+        'source': row['source'],
+        'target': row['target'],
+    }
+    return result
+
+def _build_preprocessing_functions(config):
+    '''Create functions to process source and target examples.'''
+    source_preprocess_fn = _build_source_or_target_preprocess_function(
+        config, 'source')    
+    target_preprocess_fn = _build_source_or_target_preprocess_function(
+        config, 'target')    
+    combined_fn = _compose([
+        source_preprocess_fn,
+        target_preprocess_fn,
+        _keep_only_source_and_target,
+    ])
+    return combined_fn
+    
 def create(config):
     """
     Create a dataset from the given configuration.
@@ -173,17 +245,42 @@ def create(config):
             raise ValueError(
                 'A list of languages has been specified in config as a string: '
                 f'{language}. Change to [{language}] to make it a list.')
-    
-    audio_feature = Audio(sampling_rate=16_000)
-    
-    features = datasets.Features({
-        'source': (Value('string') if config['source']['type'] == 'text'
-                   else audio_feature),
-        'target': (Value('string') if config['target']['type'] == 'text'
-                   else audio_feature),
-
+        
+    text_features = datasets.Features({
+        'text': Value('string'),
+        'language': Value('string'),
+        'origin_dataset': Value('string'),
     })
-
+    
+    audio_features = datasets.Features({
+        'audio': Audio(sampling_rate=16_000),
+        'language': Value('string'),
+        'speaker_id': Value('string'),
+        'is_studio': Value('bool'),
+    })
+    
+    features = {}
+    for source_or_target in ['source', 'target']:
+        if config[source_or_target]['type'] == 'text':
+            for k, v in text_features.items():
+                if k == 'text':
+                    features[source_or_target] = v
+                else:
+                    features[f'{source_or_target}_{k}'] = v
+        else:
+            for k, v in audio_features.items():
+                if k == 'audio':
+                    features[source_or_target] = v
+                else:
+                    features[f'{source_or_target}_{k}'] = v
+    
     generator_function = lambda: _create_generator(config)
-    return datasets.Dataset.from_generator(
-        generator_function, features=features)
+    ds = datasets.Dataset.from_generator(
+        generator_function, features=datasets.Features(features))
+
+    # Apply preprocessing
+    preprocessing_fn = _build_preprocessing_functions(config)
+    ds.set_transform(preprocessing_fn)    
+    return ds
+
+    

--- a/dataset_test.py
+++ b/dataset_test.py
@@ -131,6 +131,20 @@ class DatasetTestCase(unittest.TestCase):
       self.temp_dir.cleanup()
       
 
+    def test_preprocessing_pipeline(self):
+        def prefix_tag(r, src_or_tgt, tag="hello"):
+            for i in range(len(r['source'])):
+                r[src_or_tgt][i] = f'>{tag}< ' + r[src_or_tgt][i]
+            return r
+        
+        def random_prefix(r, src_or_tgt):
+            for i in range(len(r['source'])):
+                prefix = ''.join(
+                    random.choice(string.ascii_letters) for _ in range(3))
+                r[src_or_tgt][i] = f'>{prefix}< ' + r[src_or_tgt][i]
+            return r
+        pass
+    
     def test_text_to_speech_dataset(self):      
       yaml_config = '''
       huggingface_load:

--- a/notebooks/Leb test.ipynb
+++ b/notebooks/Leb test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "cbed12e4-cf71-4d7b-9bfe-b4e3e57c17b2",
    "metadata": {},
    "outputs": [],
@@ -25,22 +25,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "12e3e539-f3cf-43bc-9a6d-3fe7d279637c",
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8d2853c01a564680886fb22ae7709d0e",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "[{'source': 'lug1', 'target': 'eng1'},\n",
-       " {'source': 'ach1', 'target': 'eng1'},\n",
-       " {'source': 'lug2', 'target': 'eng2'},\n",
-       " {'source': 'ach2', 'target': 'eng2'},\n",
-       " {'source': 'lug3', 'target': 'eng3'},\n",
-       " {'source': 'ach3', 'target': 'eng3'}]"
+       "Generating train split: 0 examples [00:00, ? examples/s]"
       ]
      },
-     "execution_count": 6,
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'source': '>>eng<< lug1', 'target': 'eng1'},\n",
+       " {'source': '>>eng<< ach1', 'target': 'eng1'},\n",
+       " {'source': '>>eng<< lug2', 'target': 'eng2'},\n",
+       " {'source': '>>eng<< ach2', 'target': 'eng2'},\n",
+       " {'source': '>>eng<< lug3', 'target': 'eng3'},\n",
+       " {'source': '>>eng<< ach3', 'target': 'eng3'}]"
+      ]
+     },
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -56,6 +70,8 @@
     "source:\n",
     "  type: text\n",
     "  language: [lug, ach]\n",
+    "  preprocessing:\n",
+    "      - prefix_target_language\n",
     "target:\n",
     "  type: text\n",
     "  language: eng\n",

--- a/text_preprocessing.py
+++ b/text_preprocessing.py
@@ -10,7 +10,7 @@ normalizer = sacremoses.MosesPunctNormalizer()
 
 def prefix_target_language(r, src_or_tgt):
     for i in range(len(r['source'])):
-        r[src_or_tgt][i] = f'>>{r["target_language"][i]}<< ' + r[src_or_tgt][i]
+        r[src_or_tgt][i] = f'>>{r["target.language"][i]}<< ' + r[src_or_tgt][i]
     return r
 
 def sentence_format(r, src_or_tgt, add_full_stop=True):

--- a/text_preprocessing.py
+++ b/text_preprocessing.py
@@ -1,0 +1,30 @@
+'''
+Text examples have the fields:
+text, language, origin_dataset
+'''
+import string
+import random
+import sacremoses
+
+normalizer = sacremoses.MosesPunctNormalizer()  
+
+def prefix_target_language(r, src_or_tgt):
+    for i in range(len(r['source'])):
+        r[src_or_tgt][i] = f'>>{r["target_language"][i]}<< ' + r[src_or_tgt][i]
+    return r
+
+def sentence_format(r, src_or_tgt, add_full_stop=True):
+    for i in range(len(r['source'])):
+        text = r[src_or_tgt][i] 
+        text = text[0].capitalize() + text[1:]
+        if text[-1] not in ['.', '!', '?'] and add_full_stop:
+            text = text + '.'
+        r[src_or_tgt][i] = text
+    return r
+
+def normalise_text(r, src_or_tgt):
+    for i in range(len(r['source'])):
+        text = r[src_or_tgt][i]
+        text = normalizer.normalize(text)
+        r[src_or_tgt][i] = text
+    return r    


### PR DESCRIPTION
This PR contains logic so that preprocessing operations for either text or audio can be specified in yaml configuration. The raw data is downloaded from specified HuggingFace sources, then `source` and `target` entries are constructed, and then the specified transformations are applied to these to give the final ouput.

Example usage is shown in notebooks/ and also unit tests.