### PR TITLE
Multlingual metrics, dataset shuffle and audio resampling

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -75,6 +75,11 @@ def _combine_datasets_generator(left, right):
     for entry in merged_datasets:
         entry_id = int(entry['id'])
         if entry_id != current_id and current_id is not None:
+            if int(entry_id) < int(current_id):
+                raise ValueError(
+                    'To join two datasets based on the `id` field, the ids '
+                    'must be in numerical sorted order within both datasets. '
+                    f'Found id {entry_id} after {current_id}.')
             yield combined_entry
             combined_entry = {}
         current_id = entry_id

--- a/dataset.py
+++ b/dataset.py
@@ -127,6 +127,10 @@ def _load_huggingface_datasets(config):
             ds = _load_single_huggingface_dataset(l)
             dataset_id = _dataset_id_from_config(l)
         loaded_datasets.append([ds, dataset_id])
+        
+    if config.get('shuffle'):
+        loaded_datasets = [[ds[0].shuffle(), ds[1]] for ds in loaded_datasets]
+        
     return loaded_datasets
 
 def _matching_items(row, source_target_config):
@@ -330,8 +334,6 @@ def create(config):
       dataset: A datasets.Dataset object with attributes `source` and `target`.
     """
     # TODO: checks on configuration to make sure it's valid.
-    # TODO: allow interleaving multiple datasets
-    # TODO: raise warning if many rows iterated through without finding a match
    
     # Multiple source or target languages can be specified in the yaml config
     # e.g. with "language: [lug, ach]". An easy mistake is to write
@@ -345,6 +347,9 @@ def create(config):
             
     generator_function = lambda: _create_generator(config)
     ds = datasets.IterableDataset.from_generator(generator_function)
+    
+    if config.get('shuffle'):
+        ds = ds.shuffle()
 
     # Apply preprocessing
     preprocessing_fn = _build_preprocessing_functions(config)

--- a/dataset.py
+++ b/dataset.py
@@ -60,6 +60,9 @@ def _combine_datasets_generator(left, right):
             elif key == 'audio':
                 language_key = 'audio_' + entry['language']
                 combined_entry.setdefault(language_key, []).append(value)
+                sample_rate_key = f'audio_{entry["language"]}_sample_rate'
+                combined_entry.setdefault(
+                    sample_rate_key, []).append(entry['sample_rate'])                
                 speaker_id_key = f'audio_{entry["language"]}_speaker_id'
                 combined_entry.setdefault(
                     speaker_id_key, []).append(entry['speaker_id'])
@@ -138,19 +141,21 @@ def _matching_items(row, source_target_config):
                     continue
                 matches.append(
                     {'audio': row['audio'],
-                     'sample_rate': row.get('sample_rate'),
+                     'sample_rate': row['sample_rate'],
                      'language': row['language'],
                      'speaker_id': row['speaker_id'],
                      'is_studio': row['is_studio'],
                     })
             if row.get(f'audio_{language}'):
-                for audio_example, speaker_id in zip(
+                for audio_example, sample_rate, speaker_id in zip(
                     row[f'audio_{language}'],
+                    row[f'audio_{language}_sample_rate'],
                     row[f'audio_{language}_speaker_id']):
                     if speaker_id_filter and speaker_id != speaker_id_filter:
                         continue
                     matches.append({
                         'audio': audio_example,
+                        'sample_rate': sample_rate,
                         'language': language,
                         'speaker_id': speaker_id,
                         'is_studio': None,  # TODO

--- a/dataset.py
+++ b/dataset.py
@@ -322,5 +322,6 @@ def create(config):
     ds = ds.map(preprocessing_fn, batched=True, batch_size=10)
     
     if not config.get('keep_metadata_features'):
-        ds = ds.select_columns(['source', 'target'])
+        ds = ds.select_columns(
+            ['source', 'target', 'source.language', 'target.language'])
     return ds

--- a/dataset.py
+++ b/dataset.py
@@ -325,13 +325,12 @@ def create(config):
       language: Either an ISO 639-2 language code (e.g. 'eng', 'lug'),
           or a list of codes.
       type: 'text' or 'speech'.
-      recording_type: In the case of audio, 'studio', 'natural' or
-          'any' (default).
       preprocessing: list of any functions that should be applied to transform
           the data.
 
     Returns:
-      dataset: A datasets.Dataset object with attributes `source` and `target`.
+      dataset: A datasets.Dataset object with attributes `source`, `target`,
+          `source.language` and `target.language`.
     """
     # TODO: checks on configuration to make sure it's valid.
    

--- a/dataset.py
+++ b/dataset.py
@@ -296,8 +296,8 @@ def create(config):
       dataset: A datasets.Dataset object with attributes `source` and `target`.
     """
     # TODO: checks on configuration to make sure it's valid.
-    # TODO: make sample rate configurable.
     # TODO: allow interleaving multiple datasets
+    # TODO: raise warning if many rows iterated through without finding a match
    
     # Multiple source or target languages can be specified in the yaml config
     # e.g. with "language: [lug, ach]". An easy mistake is to write

--- a/dataset_test.py
+++ b/dataset_test.py
@@ -466,6 +466,46 @@ class DatasetTestCase(unittest.TestCase):
       ]
       
       self.assertNestedAlmostEqual(list(ds), expected)
+    
+    
+    def test_join_speech_translation_dataset_with_resample(self):
+      yaml_config = '''
+      huggingface_load:
+          join:
+            - path: parquet
+              data_files: PATH/audio_mock.parquet
+              split: train
+            - path: csv
+              data_files: PATH/translation_dataset_1.csv
+              split: train
+      source:
+          type: speech
+          language: lug
+          preprocessing:
+            - set_sample_rate:
+                rate: 32000
+      target:
+          type: text
+          language: eng
+      '''.replace('PATH', self.data_path)
+      config = yaml.safe_load(yaml_config)
+      ds = dataset.create(config)
+                
+      expected = [
+        {'source': np.array([.1, .1, .1]),
+         'target': 'eng1'},
+        {'source': np.array([.3, .3, .3]),
+         'target': 'eng1'},
+        {'source': np.array([.2, .2, .2]),
+         'target': 'eng2'},
+        {'source': np.array([.4, .4, .4]),
+         'target': 'eng2'}
+      ]
+    
+      result = list(ds)
+      for i in range(4):
+          self.assertEqual(len(result[i]['source']), 6)
+    
 
     def test_speech_to_speech_dataset(self):
       yaml_config = '''

--- a/dataset_test.py
+++ b/dataset_test.py
@@ -258,9 +258,22 @@ class DatasetTestCase(unittest.TestCase):
         ds = dataset.create(config)
         
         expected = [
-            {'source': 'two one lug1 three', 'target': 'eng1 four'},
-            {'source': 'two one lug2 three', 'target': 'eng2 four'},
-            {'source': 'two one lug3 three', 'target': 'eng3 four'}]
+            {'source': 'two one lug1 three',
+             'target': 'eng1 four',
+             'source.language': 'lug',
+             'target.language': 'eng',
+            },
+            {'source': 'two one lug2 three',
+             'target': 'eng2 four',
+             'source.language': 'lug',
+             'target.language': 'eng',
+            },
+            {'source': 'two one lug3 three',
+             'target': 'eng3 four',
+             'source.language': 'lug',
+             'target.language': 'eng',
+            },
+        ]
 
         self.assertEqual(list(ds), expected)
    
@@ -287,9 +300,15 @@ class DatasetTestCase(unittest.TestCase):
       
       expected = [
         {'source': 'lug1',
-         'target': np.array([.3, .3, .3])},
+         'target': np.array([.3, .3, .3]),
+         'source.language': 'lug',
+         'target.language': 'lug',
+        },
         {'source': 'lug2',
-         'target': np.array([.4, .4, .4])},
+         'target': np.array([.4, .4, .4]),
+         'source.language': 'lug',
+         'target.language': 'lug',
+        },
       ]
       
       self.assertNestedAlmostEqual(list(ds), expected)
@@ -313,9 +332,22 @@ class DatasetTestCase(unittest.TestCase):
         ds = dataset.create(config)
         
         expected = [
-            {'source': 'lug1', 'target': 'eng1'},
-            {'source': 'lug2', 'target': 'eng2'},
-            {'source': 'lug3', 'target': 'eng3'}]
+            {'source': 'lug1',
+             'target': 'eng1',
+             'source.language': 'lug',
+             'target.language': 'eng',             
+            },
+            {'source': 'lug2',
+             'target': 'eng2',
+             'source.language': 'lug',
+             'target.language': 'eng',             
+            },
+            {'source': 'lug3',
+             'target': 'eng3',
+             'source.language': 'lug',
+             'target.language': 'eng',            
+            }
+        ]
 
         self.assertEqual(list(ds), expected)
    
@@ -337,12 +369,36 @@ class DatasetTestCase(unittest.TestCase):
         ds = dataset.create(config)
         
         expected = [
-            {'source': 'lug1', 'target': 'eng1'},
-            {'source': 'lug2', 'target': 'eng2'},
-            {'source': 'lug3', 'target': 'eng3'},
-            {'source': 'ach1', 'target': 'eng1'},
-            {'source': 'ach2', 'target': 'eng2'},
-            {'source': 'ach3', 'target': 'eng3'},
+            {'source': 'lug1',
+             'target': 'eng1',
+             'source.language': 'lug',
+             'target.language': 'eng',             
+            },
+            {'source': 'lug2',
+             'target': 'eng2',
+             'source.language': 'lug',
+             'target.language': 'eng',             
+            },
+            {'source': 'lug3',
+             'target': 'eng3',
+             'source.language': 'lug',
+             'target.language': 'eng',             
+            },
+            {'source': 'ach1',
+             'target': 'eng1',
+             'source.language': 'ach',
+             'target.language': 'eng',             
+            },
+            {'source': 'ach2',
+             'target': 'eng2',
+             'source.language': 'ach',
+             'target.language': 'eng',             
+            },
+            {'source': 'ach3',
+             'target': 'eng3',
+             'source.language': 'ach',
+             'target.language': 'eng',             
+            },
         ]
 
         self.assertCountEqual(list(ds), expected)
@@ -368,11 +424,31 @@ class DatasetTestCase(unittest.TestCase):
         ds = dataset.create(config)
         
         expected = [
-            {'source': 'lug1', 'target': 'eng1'},
-            {'source': 'lug2', 'target': 'eng2'},
-            {'source': 'lug3', 'target': 'eng3'},
-            {'source': 'lug4', 'target': 'eng4'},
-            {'source': 'lug5', 'target': 'eng5'}
+            {'source': 'lug1',
+             'target': 'eng1',
+             'source.language': 'lug',
+             'target.language': 'eng',            
+            },
+            {'source': 'lug2',
+             'target': 'eng2',
+             'source.language': 'lug',
+             'target.language': 'eng',             
+            },
+            {'source': 'lug3',
+             'target': 'eng3',
+             'source.language': 'lug',
+             'target.language': 'eng',             
+            },
+            {'source': 'lug4',
+             'target': 'eng4',
+             'source.language': 'lug',
+             'target.language': 'eng',             
+            },
+            {'source': 'lug5',
+             'target': 'eng5',
+             'source.language': 'lug',
+             'target.language': 'eng',             
+            }
         ]
 
         self.assertEqual(list(ds), expected)
@@ -398,10 +474,26 @@ class DatasetTestCase(unittest.TestCase):
         ds = dataset.create(config)
         
         expected = [
-            {'source': 'lug1', 'target': 'eng1'},
-            {'source': 'lug3', 'target': 'eng3'},
-            {'source': 'lug4', 'target': 'eng4',},
-            {'source': 'lug5', 'target': 'eng5'}
+            {'source': 'lug1',
+             'target': 'eng1',
+             'source.language': 'lug',
+             'target.language': 'eng',
+            },
+            {'source': 'lug3',
+             'target': 'eng3',
+             'source.language': 'lug',
+             'target.language': 'eng',            
+            },
+            {'source': 'lug4',
+             'target': 'eng4',
+             'source.language': 'lug',
+             'target.language': 'eng',            
+            },
+            {'source': 'lug5',
+             'target': 'eng5',
+             'source.language': 'lug',
+             'target.language': 'eng',            
+            }
         ]
 
         self.assertEqual(list(ds), expected)
@@ -424,13 +516,26 @@ class DatasetTestCase(unittest.TestCase):
       
       expected = [
         {'source': np.array([.1, .1, .1]),
-         'target': 'lug1'},
+         'target': 'lug1',
+         'source.language': 'lug',
+         'target.language': 'lug',        
+        },
         {'source': np.array([.3, .3, .3]),
-         'target': 'lug1'},
+         'target': 'lug1',
+         'source.language': 'lug',
+         'target.language': 'lug',          
+        },
         {'source': np.array([.2, .2, .2]),
-         'target': 'lug2'},
+         'target': 'lug2',
+         'source.language': 'lug',
+         'target.language': 'lug',          
+        },
         {'source': np.array([.4, .4, .4]),
-         'target': 'lug2'}]
+         'target': 'lug2',
+         'source.language': 'lug',
+         'target.language': 'lug',          
+        }
+      ]
       
       self.assertNestedAlmostEqual(list(ds), expected)
     
@@ -456,13 +561,25 @@ class DatasetTestCase(unittest.TestCase):
         
       expected = [
         {'source': np.array([.1, .1, .1]),
-         'target': 'eng1'},
+         'target': 'eng1',
+         'source.language': 'lug',
+         'target.language': 'eng',          
+        },
         {'source': np.array([.3, .3, .3]),
-         'target': 'eng1'},
+         'target': 'eng1',
+         'source.language': 'lug',
+         'target.language': 'eng',        
+        },
         {'source': np.array([.2, .2, .2]),
-         'target': 'eng2'},
+         'target': 'eng2',
+         'source.language': 'lug',
+         'target.language': 'eng',        
+        },
         {'source': np.array([.4, .4, .4]),
-         'target': 'eng2'}
+         'target': 'eng2',
+         'source.language': 'lug',
+         'target.language': 'eng',        
+        }
       ]
       
       self.assertNestedAlmostEqual(list(ds), expected)
@@ -493,13 +610,25 @@ class DatasetTestCase(unittest.TestCase):
                 
       expected = [
         {'source': np.array([.1, .1, .1]),
-         'target': 'eng1'},
+         'target': 'eng1',
+         'source.language': 'lug',
+         'target.language': 'eng',        
+        },
         {'source': np.array([.3, .3, .3]),
-         'target': 'eng1'},
+         'target': 'eng1',
+         'source.language': 'lug',
+         'target.language': 'eng',        
+        },
         {'source': np.array([.2, .2, .2]),
-         'target': 'eng2'},
+         'target': 'eng2',
+         'source.language': 'lug',
+         'target.language': 'eng',        
+        },
         {'source': np.array([.4, .4, .4]),
-         'target': 'eng2'}
+         'target': 'eng2',
+         'source.language': 'lug',
+         'target.language': 'eng',        
+        }
       ]
     
       result = list(ds)
@@ -529,9 +658,15 @@ class DatasetTestCase(unittest.TestCase):
       
       expected = [
         {'source': np.array([.1, .1, .1]),
-         'target': np.array([.8, .8, .8])},
+         'target': np.array([.8, .8, .8]),
+         'source.language': 'lug',
+         'target.language': 'ach',        
+        },
         {'source': np.array([.3, .3, .3]),
-         'target': np.array([.8, .8, .8])},
+         'target': np.array([.8, .8, .8]),
+         'source.language': 'lug',
+         'target.language': 'ach',        
+        },
       ]
 
       self.assertNestedAlmostEqual(list(ds), expected)

--- a/dataset_test.py
+++ b/dataset_test.py
@@ -89,23 +89,25 @@ class DatasetTestCase(unittest.TestCase):
             'eng_text': ['eng1', 'eng2', 'eng3'],
         }
         
+
+                
         audio_metadata = {
             'id': [1, 1, 1, 1, 2, 2, 2, 3,],
             'audio': [
-                f'{audio_path}/lug1.wav',
-                f'{audio_path}/lug1_studio.wav',
-                f'{audio_path}/eng1.wav',
-                f'{audio_path}/ach1.wav',
-                f'{audio_path}/lug2.wav',
-                f'{audio_path}/lug2_studio.wav',
-                f'{audio_path}/eng2.wav',
-                f'{audio_path}/eng3.wav',
-                
+                [.1, .1, .1],
+                [.3, .3, .3],
+                [.5, .5, .5],
+                [.8, .8, .8],
+                [.2, .2, .2],
+                [.4, .4, .4],
+                [.6, .6, .6],
+                [.7, .7, .7],
             ],
+            'sample_rate': [16_000] * 8,
             'text': [
               'lug1', 'lug1', 'eng1', 'ach1', 'lug2',  'lug2',  'eng2', 'eng3'],
             'audio_language': [
-              'lug', 'lug', 'eng', 'ach', 'lug', 'lug', 'eng', 'ach'],
+              'lug', 'lug', 'eng', 'ach', 'lug', 'lug', 'eng', 'eng'],
             'is_studio': [
               False, False, True, True, False, False, False, False],
             'speaker_id': [
@@ -119,36 +121,39 @@ class DatasetTestCase(unittest.TestCase):
                 'eng-001',
             ]   
         }
-
+        
+        # Phrase ID 3 comes before IDs 1 and 2
         audio_metadata_unsorted = {
-            'id': [1, 2, 1, 2, 1, 2, 3, 1],
+            'id': [3, 1, 1, 1, 1, 2, 2, 2],
             'audio': [
-                f'{audio_path}/lug1.wav',
-                f'{audio_path}/lug2.wav',
-                f'{audio_path}/lug1_studio.wav',
-                f'{audio_path}/lug2_studio.wav',
-                f'{audio_path}/eng1.wav',
-                f'{audio_path}/eng2.wav',
-                f'{audio_path}/eng3.wav',
-                f'{audio_path}/ach1.wav',
+                [.7, .7, .7],
+                [.1, .1, .1],
+                [.3, .3, .3],
+                [.5, .5, .5],
+                [.8, .8, .8],
+                [.2, .2, .2],
+                [.4, .4, .4],
+                [.6, .6, .6],
             ],
+            'sample_rate': [16_000] * 8,
             'text': [
-              'lug1', 'lug2', 'lug1', 'lug2', 'eng1', 'eng2', 'eng3', 'ach1'],
+              'eng3', 'lug1', 'lug1', 'eng1', 'ach1', 'lug2',  'lug2', 'eng2'],
             'audio_language': [
-              'lug', 'lug', 'lug', 'lug', 'eng', 'eng', 'eng', 'ach'],
+              'eng', 'lug', 'lug', 'eng', 'ach', 'lug', 'lug', 'eng'],
             'is_studio': [
               False, False, True, True, False, False, False, False],
             'speaker_id': [
-                'lug-001',
-                'lug-002',
-                'lug-studio-1',
-                'lug-studio-1',
                 'eng-001',
-                'eng-002',
+                'lug-001',
+                'lug-studio-1',
                 'eng-001',
                 'ach-001',
-            ]
+                'lug-002',
+                'lug-studio-1',
+                'eng-002',
+            ]   
         }
+        
 
         temp_csv_path = f'{self.data_path}/translation_dataset_1.csv'
         pd.DataFrame(translate_data_1).to_csv(temp_csv_path, index=False)    
@@ -160,12 +165,11 @@ class DatasetTestCase(unittest.TestCase):
         pd.DataFrame(translate_data_missing_value).to_csv(
           temp_csv_path, index=False)
 
-        audio_dataset = datasets.Dataset.from_dict(audio_metadata).cast_column(
-          'audio', datasets.Audio(sampling_rate=16000))
+        audio_dataset = datasets.Dataset.from_dict(audio_metadata)
         audio_dataset.to_parquet(f'{self.data_path}/audio_mock.parquet')
 
-        audio_dataset_unsorted = datasets.Dataset.from_dict(audio_metadata_unsorted).cast_column(
-            'audio', datasets.Audio(sampling_rate=16000))
+        audio_dataset_unsorted = datasets.Dataset.from_dict(
+            audio_metadata_unsorted)
         audio_dataset_unsorted.to_parquet(
             f'{self.data_path}/audio_mock_unsorted.parquet')
         
@@ -283,13 +287,9 @@ class DatasetTestCase(unittest.TestCase):
       
       expected = [
         {'source': 'lug1',
-         'target': {'path': None,
-                    'array': np.array([.3, .3, .3]),
-                    'sampling_rate': 16000}},
+         'target': np.array([.3, .3, .3])},
         {'source': 'lug2',
-         'target': {'path': None,
-                    'array': np.array([.4, .4, .4]),
-                    'sampling_rate': 16000}},
+         'target': np.array([.4, .4, .4])},
       ]
       
       self.assertNestedAlmostEqual(list(ds), expected)
@@ -423,21 +423,13 @@ class DatasetTestCase(unittest.TestCase):
       ds = dataset.create(config)
       
       expected = [
-        {'source': {'path': None,
-                    'array': np.array([.1, .1, .1]),
-                    'sampling_rate': 16000},
+        {'source': np.array([.1, .1, .1]),
          'target': 'lug1'},
-        {'source': {'path': None,
-                    'array': np.array([.2, .2, .2]),
-                    'sampling_rate': 16000},
+        {'source': np.array([.3, .3, .3]),
+         'target': 'lug1'},
+        {'source': np.array([.2, .2, .2]),
          'target': 'lug2'},
-        {'source': {'path': None,
-                    'array': np.array([.3, .3, .3]),
-                    'sampling_rate': 16000},
-         'target': 'lug1'},
-        {'source': {'path': None,
-                    'array': np.array([.4, .4, .4]),
-                    'sampling_rate': 16000},
+        {'source': np.array([.4, .4, .4]),
          'target': 'lug2'}]
       
       self.assertNestedAlmostEqual(list(ds), expected)
@@ -463,22 +455,15 @@ class DatasetTestCase(unittest.TestCase):
       ds = dataset.create(config)
         
       expected = [
-        {'source': {'path': None,
-                    'array': np.array([.1, .1, .1]),
-                    'sampling_rate': 16000},
+        {'source': np.array([.1, .1, .1]),
          'target': 'eng1'},
-        {'source': {'path': None,
-                    'array': np.array([.3, .3, .3]),
-                    'sampling_rate': 16000},
+        {'source': np.array([.3, .3, .3]),
          'target': 'eng1'},
-        {'source': {'path': None,
-                    'array': np.array([.2, .2, .2]),
-                    'sampling_rate': 16000},
+        {'source': np.array([.2, .2, .2]),
          'target': 'eng2'},
-        {'source': {'path': None,
-                    'array': np.array([.4, .4, .4]),
-                    'sampling_rate': 16000},
-         'target': 'eng2'}]
+        {'source': np.array([.4, .4, .4]),
+         'target': 'eng2'}
+      ]
       
       self.assertNestedAlmostEqual(list(ds), expected)
 
@@ -503,18 +488,10 @@ class DatasetTestCase(unittest.TestCase):
       ds = dataset.create(config)
       
       expected = [
-        {'source': {'path': None,
-                    'array': np.array([.1, .1, .1]),
-                    'sampling_rate': 16000},
-         'target': {'path': None,
-                    'array': np.array([.8, .8, .8]),
-                    'sampling_rate': 16000}},
-        {'source': {'path': None,
-                    'array': np.array([.3, .3, .3]),
-                    'sampling_rate': 16000},
-         'target': {'path': None,
-                    'array': np.array([.8, .8, .8]),
-                    'sampling_rate': 16000}},
+        {'source': np.array([.1, .1, .1]),
+         'target': np.array([.8, .8, .8])},
+        {'source': np.array([.3, .3, .3]),
+         'target': np.array([.8, .8, .8])},
       ]
 
       self.assertNestedAlmostEqual(list(ds), expected)

--- a/dataset_test.py
+++ b/dataset_test.py
@@ -181,7 +181,7 @@ class DatasetTestCase(unittest.TestCase):
         self.temp_dir.cleanup()
         warnings.simplefilter("default", ResourceWarning)
       
-    
+    #"""
     def test_preprocessing_augmentation(self):
         def random_prefix(r, src_or_tgt):
             for i in range(len(r['source'])):
@@ -670,11 +670,32 @@ class DatasetTestCase(unittest.TestCase):
       ]
 
       self.assertNestedAlmostEqual(list(ds), expected)
+    #"""
         
-    # TODO: check error is raised if trying to join when IDs are unsorted
-    
-    # TODO: audio files of different sample rates
-    
+    def test_join_unsorted_raises_exception(self):
+      def try_creating_unsorted():  
+          yaml_config = '''
+          huggingface_load:
+              join:
+                - path: parquet
+                  data_files: PATH/audio_mock_unsorted.parquet
+                  split: train
+                - path: csv
+                  data_files: PATH/translation_dataset_1.csv
+                  split: train
+          source:
+              type: speech
+              language: lug
+          target:
+              type: text
+              language: eng
+          '''.replace('PATH', self.data_path)
+          config = yaml.safe_load(yaml_config)
+          ds = dataset.create(config)
+          list(ds)
+      self.assertRaises(ValueError, try_creating_unsorted) 
+
+        
 if __name__ == '__main__':
     unittest.main()
 

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pandas as pd
+
+def multilingual_eval(eval_preds,
+                      source_language,
+                      target_language,
+                      metrics,
+                      metric_names,
+                      tokenizer,
+                      log_first_N_predictions):
+    '''Compute metric scores for each source and target language combination.'''
+    
+    predictions, labels = eval_preds
+    if isinstance(predictions, tuple):
+        predictions = predictions[0]
+
+    decoded_predictions = tokenizer.batch_decode(
+        predictions, skip_special_tokens=True)
+
+    # Replace -100 in the labels as we can't decode them.
+    labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+
+    if log_first_N_predictions:
+        for i in range(log_first_N_predictions):
+            print(f'prediction: {decoded_predictions[i]}, '
+                  f'true: {decoded_labels[i]}')
+
+    subsets = {}
+    for i in range(len(predictions)):
+        language_combination = source_language[i] + '_' + target_language[i]
+        if language_combination not in subsets:
+            subsets[language_combination] = {'predictions': [], 'labels': []}
+        subsets[language_combination]['predictions'].append(
+            decoded_predictions[i])
+        subsets[language_combination]['labels'].append(decoded_labels[i])
+           
+    result = {}
+    for metric, metric_name in zip(metrics, metric_names):
+        for subset in list(subsets.keys()):
+            result_subset = metric.compute(
+                predictions=subsets[subset]['predictions'],
+                references=subsets[subset]['labels'])
+            if metric_name == 'BLEU':
+                # The sacrebleu and bleu implementations have different formats
+                r = result_subset.get('score') or result_subset.get('bleu')
+            elif metric_name == 'WER':
+                r = result_subset
+            else:
+                raise ValueError('Only BLEU and WER metrics currently '
+                                 'supported.')
+            result[f'{metric_name}_{subset}'] = r 
+        
+    result[f'{metric_name}_mean'] = np.mean(
+        [result[f'{metric_name}_{subset}'] for subset in list(subsets.keys())]
+    )
+
+    result = {k: round(v, 3) for k, v in result.items()}
+    return result
+
+def multilingual_eval_fn(eval_dataset,
+                         metric,
+                         metric_name,
+                         tokenizer,
+                         log_first_N_predictions=3):
+    '''Return a function with the signature `eval_fn(preds)`.'''
+   
+    df = pd.DataFrame(ds)
+    source_language = list(df['source.language'])
+    target_language = list(df['target.language'])
+    
+    return functools.partial(multilingual_eval,
+                             source_language,
+                             target_language,
+                             metrics,
+                             metric_names,
+                             tokenizer,
+                             log_first_N_predictions=log_first_N_predictions)

--- a/metrics_test.py
+++ b/metrics_test.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import numpy as np
+import evaluate
+
+from .metrics import multilingual_eval, multilingual_eval_fn
+
+# Helper function to create a mock tokenizer
+def create_mock_tokenizer():
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.batch_decode = MagicMock(
+        side_effect=(lambda x, skip_special_tokens:
+            [' '.join([str(i) for i in r]) for r in x]))
+    mock_tokenizer.pad_token_id = 0
+    return mock_tokenizer
+
+# Define our unit test case
+class MultilingualEvalUnitTest(unittest.TestCase):
+    
+    def test_multilingual_eval(self):
+        mock_tokenizer = create_mock_tokenizer()
+        metric = evaluate.load('sacrebleu')
+
+        predictions = np.array([[1, 2, 3, 4], [4, 5, 6, 6]])
+        labels = np.array([[1, 2, 3, 4], [4, 5, 3, 6]])
+
+        eval_preds = (predictions, labels)
+        source_language = ['lug', 'ach']
+        target_language = ['nyn', 'teo']
+        metrics = [metric]
+        metric_names = ['BLEU']
+        log_first_N_predictions = 0
+        
+        result = multilingual_eval(eval_preds,
+                                   source_language,
+                                   target_language,
+                                   metrics,
+                                   metric_names,
+                                   mock_tokenizer,
+                                   log_first_N_predictions)
+
+        # Assert: Check if the output matches the expected result
+        self.assertAlmostEqual(result['BLEU_lug_nyn'], 100.0)
+        self.assertAlmostEqual(result['BLEU_ach_teo'], 35.355)
+        # Assert function calls of tokenizer
+        mock_tokenizer.batch_decode.assert_called()
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -117,6 +117,6 @@ def set_sample_rate(r, src_or_tgt, rate):
             audio_data, orig_sr=current_sample_rate, target_sr=rate)
         r[src_or_tgt] = resampled_audio_data
         r[f'{src_or_tgt}.sample_rate'] = rate
-        
+    
     return r
     

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -103,6 +103,13 @@ def lower_case(r, src_or_tgt):
     return r
 
 @single_batch_entry
+def random_capitalise_source_and_target(r, src_or_tgt, p=0.005):
+    if np.random.random() < p:
+        r['source'] = r['source'].upper()
+        r['target'] = r['target'].upper()
+    return r
+
+@single_batch_entry
 def set_sample_rate(r, src_or_tgt, rate):
     '''Resamples audio data, if the sample rate in the record is different.'''
     current_sample_rate = r[f'{src_or_tgt}.sample_rate']

--- a/preprocessing_test.py
+++ b/preprocessing_test.py
@@ -22,24 +22,27 @@ class TestPreprocessing(unittest.TestCase):
         result = preprocessing.prefix_target_language(self.record, 'source')
         self.assertEqual(result['source'], expected)
 
-    def test_sentence_format(self):
-        # Test with default add_full_stop
-        record = {'source': ['test sentence']}
-        expected = ['Test sentence.']
-        result = preprocessing.sentence_format(record, 'source')
-        self.assertEqual(result['source'], expected)
+    def test_match_target_sentence_format_to_source(self):
+        # Full_stop in source
+        record = {'source': ['test sentence.'],
+                  'target': ['translated sentence']}
+        expected = ['translated sentence.']
+        result = preprocessing.match_target_sentence_format_to_source(
+            record, 'target')
+        self.assertEqual(result['target'], expected)
+        
+        # Initial capital and no full stop
+        record = {'source': ['Test sentence'],
+                  'target': ['translated sentence.']}
+        expected = ['Translated sentence']
+        result = preprocessing.match_target_sentence_format_to_source(
+            record, 'target')
+        self.assertEqual(result['target'], expected)
 
-        # Test without full stop
-        record = {'source': ['test sentence']}
-        expected = ['Test sentence']
-        result = preprocessing.sentence_format(
-            record, 'source', add_full_stop=False)
-        self.assertEqual(result['source'], expected)
-
-    def test_normalise_text(self):
-        record = {'source': ['“Hello, World!”']}
-        expected = ['"Hello, World!"']
-        result = preprocessing.normalise_text(record, 'source')
+    def test_clean_text(self):
+        record = {'source': ['\\u2018Hello\\u2019 &lt;']}
+        expected = ["'Hello' <"]
+        result = preprocessing.clean_text(record, 'source')
         self.assertEqual(result['source'], expected)
 
     def test_augment_characters(self):
@@ -61,10 +64,10 @@ class TestPreprocessing(unittest.TestCase):
         self.assertNotEqual(['source text'], record['source'])
         self.assertEqual(len('source text'), len(record['source'][0]))
 
-    def test_remove_punctuation(self):
-        record = {'source': ['hello, world!']}
+    def test_clean_and_remove_punctuation(self):
+        record = {'source': ['&lt;hello,&gt; world!']}
         expected = ['hello world']
-        result = preprocessing.remove_punctuation(record, 'source')
+        result = preprocessing.clean_and_remove_punctuation(record, 'source')
         self.assertEqual(result['source'], expected)
 
     def test_lower_case(self):

--- a/preprocessing_test.py
+++ b/preprocessing_test.py
@@ -45,6 +45,13 @@ class TestPreprocessing(unittest.TestCase):
         result = preprocessing.clean_text(record, 'source')
         self.assertEqual(result['source'], expected)
 
+    def test_capitalise_source_and_target(self):
+        record = {'source': ['some words'], 'target': ['translated']}
+        result = preprocessing.random_capitalise_source_and_target(
+            record, 'source', p=1.0)
+        self.assertEqual(result['source'], ['SOME WORDS'])
+        self.assertEqual(result['target'], ['TRANSLATED'])
+        
     def test_augment_characters(self):
         record = {'source': ['source text']}
         char_augmentation_params = {'action': 'swap'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 datasets
 nlpaug
-sacremoses
 pandas
 numpy
 librosa
+unidecode
+clean-text

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 librosa
 unidecode
 clean-text
+evaluate


### PR DESCRIPTION
This PR adds some functionality:
- The computation of multilingual metrics, e.g. if want to compute BLEU scores in a single experiment where there are may combinations of source and target languages in the eval dataset.
- Shuffling of data, including randomly interleaving datasets.
- Add audio rate resampling as a preprocessing option. This can be used to make sure that all audio is the right sample rate.