### PR TITLE
Allow multilingual training of NLLB models

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -209,6 +209,17 @@ def _matching_pairs(row, config):
                     example['target.' + k] = v
                 else:
                     example['target'] = v
+                    
+            if (example['source.language'] == example['target.language'] and
+                not config.get('allow_same_src_and_tgt_language', True)):
+                continue
+            
+            required_language = config.get('src_or_tgt_languages_must_contain')
+            if required_language:
+                if not (example['source.language'] == required_language or
+                        example['target.language'] == required_language):
+                    continue
+                
             yield example
     
 


### PR DESCRIPTION
This PR contains code to allow Facebook translation models (mBART, NLLB, M2M100) to be trained with multiple target languages, so that they can be fine tuned for one-to-many or many-to-many versions. By default, the HuggingFace implementation can only be trained with a single target language.