### PR TITLE
Support multilingual WER evaluation

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -2,29 +2,41 @@ import numpy as np
 import pandas as pd
 import functools
 
+
 def multilingual_eval(eval_preds,
                       source_language,
                       target_language,
                       metrics,
                       metric_names,
                       tokenizer,
-                      log_first_N_predictions):
+                      log_first_N_predictions,
+                      speech_processor=None):
     '''Compute metric scores for each source and target language combination.'''
     def _round_if_float(f, p):
-      if isinstance(f, float):
-        return round(f, p)
-      else:
-        return f
-    
-    predictions, labels = eval_preds
-    # Replace -100 values as we can't decode them.
-    predictions = np.where(
-      predictions != -100, predictions, tokenizer.pad_token_id)
-    decoded_predictions = tokenizer.batch_decode(
-        predictions, skip_special_tokens=True)
+        if isinstance(f, float):
+            return round(f, p)
+        else:
+            return f
 
-    labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
-    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+    if speech_processor:
+        pred_logits = eval_preds.predictions
+        pred_ids = np.argmax(pred_logits, axis=-1)
+        eval_preds.label_ids[eval_preds.label_ids == -
+                             100] = speech_processor.tokenizer.pad_token_id
+        decoded_predictions = speech_processor.batch_decode(pred_ids)
+        # we do not want to group tokens when computing the metrics
+        decoded_labels = speech_processor.batch_decode(
+            eval_preds.label_ids, group_tokens=False)
+    else:
+        predictions, labels = eval_preds
+        # Replace -100 values as we can't decode them.
+        predictions = np.where(
+            predictions != -100, predictions, tokenizer.pad_token_id)
+        decoded_predictions = tokenizer.batch_decode(
+            predictions, skip_special_tokens=True)
+        labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+        decoded_labels = tokenizer.batch_decode(
+            labels, skip_special_tokens=True)
 
     if log_first_N_predictions:
         print('First N predictions in eval set:')
@@ -34,14 +46,22 @@ def multilingual_eval(eval_preds,
                   f'True label: "{decoded_labels[i]}"')
 
     subsets = {}
-    for i in range(len(predictions)):
-        language_combination = source_language[i] + '_' + target_language[i]
+    for i in range(len(decoded_predictions)):
+        if speech_processor:
+            # For speech metrics, such as WER, we evaluate for separate target
+            # languages.
+            language_combination = target_language[i]
+        else:
+            # For translation metrics, such as BLEU, we want metrics for every
+            # source/target combination.
+            language_combination = source_language[i] + \
+                '_' + target_language[i]
         if language_combination not in subsets:
             subsets[language_combination] = {'predictions': [], 'labels': []}
         subsets[language_combination]['predictions'].append(
             decoded_predictions[i])
         subsets[language_combination]['labels'].append(decoded_labels[i])
-           
+
     result = {}
     for metric, metric_name in zip(metrics, metric_names):
         for subset in list(subsets.keys()):
@@ -56,11 +76,10 @@ def multilingual_eval(eval_preds,
             else:
                 raise ValueError('Only BLEU and WER metrics currently '
                                  'supported.')
-            result[f'{metric_name}_{subset}'] = r 
-            
-            
+            result[f'{metric_name}_{subset}'] = r
+
         subset_values = [result[f'{metric_name}_{subset}']
-                         for subset in list(subsets.keys())]  
+                         for subset in list(subsets.keys())]
         try:
             result[f'{metric_name}_mean'] = np.mean(subset_values)
         except TypeError:
@@ -69,23 +88,30 @@ def multilingual_eval(eval_preds,
     result = {k: _round_if_float(v, 3) for k, v in result.items()}
     return result
 
+
 def multilingual_eval_fn(eval_dataset,
                          metrics,
                          tokenizer,
-                         log_first_N_predictions=0):
-    '''Return a function with the signature `eval_fn(preds)`.'''
-   
+                         log_first_N_predictions=0,
+                         speech_processor=None):
+    '''Return a function with the signature `eval_fn(preds)`.
+
+    If `speech_processor` is defined, then it is used to decode the predictions.
+    Otherwise `tokenizer` is used (e.g. for translation tasks).'''
+
     df = pd.DataFrame(eval_dataset)
     source_language = list(df['source.language'])
     target_language = list(df['target.language'])
-    
+
     metric_names = []
     for m in metrics:
         if m.name == 'sacrebleu':
             metric_names.append('BLEU')
+        elif m.name == 'wer':
+            metric_names.append('WER')
         else:
             metric_names.append(m.name)
-        
+
     return lambda x: multilingual_eval(
         x,
         source_language,
@@ -93,4 +119,5 @@ def multilingual_eval_fn(eval_dataset,
         metrics,
         metric_names,
         tokenizer,
-        log_first_N_predictions=log_first_N_predictions)
+        log_first_N_predictions=log_first_N_predictions,
+        speech_processor=speech_processor)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -98,12 +98,17 @@ def augment_words(r, src_or_tgt, **word_augmentation_params):
     return r
 
 @single_batch_entry
-def clean_and_remove_punctuation(r, src_or_tgt, **clean_text_args):
+def clean_and_remove_punctuation(
+    r, src_or_tgt, allowed_punctuation=None, **clean_text_args):
     r[src_or_tgt] = cleantext.clean(
-        r[src_or_tgt], to_ascii=False, no_punct=True, **clean_text_args)
-    # The cleantext library doesn't remove all punctuation marks.
-    r[src_or_tgt] = r[src_or_tgt].translate(
-        str.maketrans('', '', string.punctuation))
+        r[src_or_tgt], to_ascii=False, no_punct=False, **clean_text_args)
+    
+    punct = list(string.punctuation)
+    if allowed_punctuation:
+        for allowed in allowed_punctuation:
+            punct.remove(allowed)
+        
+    r[src_or_tgt] = ''.join([c for c in r[src_or_tgt] if c not in punct])
     return r
     
 @single_batch_entry

--- a/preprocessing_test.py
+++ b/preprocessing_test.py
@@ -76,6 +76,13 @@ class TestPreprocessing(unittest.TestCase):
         expected = ['hello world']
         result = preprocessing.clean_and_remove_punctuation(record, 'source')
         self.assertEqual(result['source'], expected)
+        
+        record = {'source': ["Hello! I'm here."]}
+        expected = ["hello i'm here"]
+        result = preprocessing.clean_and_remove_punctuation(
+            record, 'source', allowed_punctuation="'")
+        self.assertEqual(result['source'], expected)
+        
 
     def test_lower_case(self):
         record = {'source': ['HELLO, WoRld.']}


### PR DESCRIPTION
This PR contains changes to metrics for the case that a multilingual ASR model is being trained. In this case we would like to see word error rates for each of the languages individually, as well as a mean WER across all languages.

Example usage:

```
compute_metrics = multilingual_eval_fn(
      valid_ds, [evaluate.load('wer')],
      tokenizer, log_first_N_predictions=2,
      speech_processor=processor)
```

When this function is passed to a `Trainer`, it gives eval metrics like this:

```
{'eval_loss': 0.26461261510849,
 'eval_WER_lug': 0.359,
 'eval_WER_eng': 0.236,
 'eval_WER_mean': 0.297,
 'eval_runtime': 26.482,
 'eval_samples_per_second': 7.666,
 'eval_steps_per_second': 0.982}
```