### PR TITLE
Text normalisation during metric calculation

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -1,7 +1,35 @@
+import re
+import string
 import numpy as np
 import pandas as pd
 import functools
 import numbers
+
+
+def _normalise(string_list,
+               lower_case_and_strip_punctuation,
+               allowed_punctuation="'"):
+  '''Convert a list of strings by converting to lower case and removing
+  punctuation. This helps when calculating metrics such as WER, as we're
+  interested in which words were predicted more than the capitalisation
+  or punctuation.'''
+  if isinstance(string_list, str):
+    raise ValueError(
+        'The _normalise() function is applied to lists of strings, not '
+        'strings directly.')
+
+  if not lower_case_and_strip_punctuation:
+    return string_list
+
+  result = []
+  for s in string_list:
+    s = s.lower()
+    punct = list(string.punctuation)
+    if allowed_punctuation:
+        for allowed in allowed_punctuation:
+            punct.remove(allowed)
+    result.append(''.join([c for c in s if c not in punct]))
+  return result
 
 
 def multilingual_eval(eval_preds,
@@ -11,7 +39,9 @@ def multilingual_eval(eval_preds,
                       metric_names,
                       tokenizer,
                       log_first_N_predictions,
-                      speech_processor=None):
+                      speech_processor=None,
+                      lower_case_and_strip_punctuation=True,
+                      allowed_punctuation="'"):
     '''Compute metric scores for each source and target language combination.'''
     def _round_if_float(f, p):
         if isinstance(f, float):
@@ -67,8 +97,13 @@ def multilingual_eval(eval_preds,
     for metric, metric_name in zip(metrics, metric_names):
         for subset in list(subsets.keys()):
             result_subset = metric.compute(
-                predictions=subsets[subset]['predictions'],
-                references=subsets[subset]['labels'])
+                predictions=_normalise(subsets[subset]['predictions'],
+                                       lower_case_and_strip_punctuation,
+                                       allowed_punctuation),
+                references=_normalise(subsets[subset]['labels'],
+                                      lower_case_and_strip_punctuation,
+                                       allowed_punctuation),
+            )
             if metric_name == 'BLEU':
                 # The sacrebleu and bleu implementations have different formats
                 r = result_subset.get('score') or result_subset.get('bleu')
@@ -98,7 +133,9 @@ def multilingual_eval_fn(eval_dataset,
                          metrics,
                          tokenizer,
                          log_first_N_predictions=0,
-                         speech_processor=None):
+                         speech_processor=None,
+                         lower_case_and_strip_punctuation=True,
+                         allowed_punctuation="'"):
     '''Return a function with the signature `eval_fn(preds)`.
 
     If `speech_processor` is defined, then it is used to decode the predictions.
@@ -123,4 +160,6 @@ def multilingual_eval_fn(eval_dataset,
         metric_names,
         tokenizer,
         log_first_N_predictions=log_first_N_predictions,
-        speech_processor=speech_processor)
+        speech_processor=speech_processor,
+        lower_case_and_strip_punctuation=lower_case_and_strip_punctuation,
+        allowed_punctuation=allowed_punctuation)

--- a/metrics_test.py
+++ b/metrics_test.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import evaluate
 
-from .metrics import multilingual_eval, multilingual_eval_fn
+from .metrics import multilingual_eval, multilingual_eval_fn, _normalise
 
 # Helper function to create a mock tokenizer
 def create_mock_tokenizer():
@@ -11,6 +11,15 @@ def create_mock_tokenizer():
     mock_tokenizer.batch_decode = MagicMock(
         side_effect=(lambda x, skip_special_tokens:
             [' '.join([str(i) for i in r]) for r in x]))
+    mock_tokenizer.pad_token_id = 0
+    return mock_tokenizer
+
+# Mock tokenizer that converts ascii values to text
+def create_mock_ascii_tokenizer():
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.batch_decode = MagicMock(
+        side_effect=(lambda x, skip_special_tokens:
+            [''.join([chr(i) for i in r]) for r in x]))
     mock_tokenizer.pad_token_id = 0
     return mock_tokenizer
 
@@ -76,6 +85,49 @@ class MultilingualEvalUnitTest(unittest.TestCase):
         self.assertAlmostEqual(result['BLEU_lug_nyn'], 100.0)
         self.assertAlmostEqual(result['BLEU_ach_teo'], 35.355)   
         self.assertAlmostEqual(result['CER_ach_teo'], 0.143)
+
+
+    def test_text_normalisation(self):
+        self.assertEqual(_normalise(["Hello!", "isn't IT?"], True),
+                         ["hello", "isn't it"])
+
+    def test_normalisation_applied(self):
+
+        tokenizer = create_mock_ascii_tokenizer()
+        predictions = [list('abc def'.encode('ascii'))]
+        labels = [list('Abc Def?'.encode('ascii'))]
+
+        eval_preds = (predictions, labels)
+
+        source_language = ['lug']
+        target_language = ['nyn']
+        eval_dataset = {
+            'source.language': source_language,
+            'target.language': target_language,
+        }
+        
+        metrics = [evaluate.load('wer')]
+        
+        # Without text normalisation, all predicted words are wrong
+        compute_metrics = multilingual_eval_fn(
+            eval_dataset,
+            metrics,
+            tokenizer,
+            lower_case_and_strip_punctuation=False,
+        )
+        result = compute_metrics(eval_preds)
+        self.assertAlmostEqual(result['WER_lug_nyn'], 1.0)
+
+        # With normalisation, predictions and labels should match
+        compute_metrics = multilingual_eval_fn(
+            eval_dataset,
+            metrics,
+            tokenizer,
+            lower_case_and_strip_punctuation=True,
+        )
+        result = compute_metrics(eval_preds)
+        self.assertAlmostEqual(result['WER_lug_nyn'], 0.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously we calculated metrics (BLEU, WER, etc) directly on the predicted text and labels. However this means that the metrics change depending on whether there is capitalisation or punctuation. This PR adds some default normalisation to text, converting to lower case and stripping out most punctuation, so that metrics stay consistent.