### PR TITLE
Add constants file

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -7,6 +7,8 @@ SALT_LANGUAGE_NAMES = {
     'nyn': 'Runyankole',
     'swa': 'Swahili',
     'teo': 'Ateso',
+    'xog': 'Lusoga',
+    'ttj': 'Rutooro',
 }
 
 SALT_LANGUAGE_TOKENS_WHISPER = {
@@ -19,6 +21,8 @@ SALT_LANGUAGE_TOKENS_WHISPER = {
     'lug': 50355,
     'nyn': 50354,
     'teo': 50353,
+    'xog': 50352,
+    'ttj': 50351,
 }
 
 SALT_LANGUAGE_TOKENS_NLLB_TRANSLATION = {
@@ -32,4 +36,6 @@ SALT_LANGUAGE_TOKENS_NLLB_TRANSLATION = {
     'nyn': 256002,
     'teo': 256006,
     'lgg': 256008,
+    'xog': 256009,
+    'ttj': 256010,
 }

--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,6 @@
 SALT_LANGUAGE_NAMES = {
     'ach': 'Acholi',
-    'eng': 'English,
+    'eng': 'English',
     'ibo': 'Igbo',
     'lgg': 'Lugbara',
     'lug': 'Luganda',

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,24 @@
+SALT_LANGUAGE_TOKENS_WHISPER = {
+    # Exact/close mapping
+    'eng': 50259,
+    'swa': 50318,
+    # Overwrite unused language tokens
+    'ach': 50357,
+    'lgg': 50356,
+    'lug': 50355,
+    'nyn': 50354,
+    'teo': 50353,
+}
+
+SALT_LANGUAGE_TOKENS_NLLB_TRANSLATION = {
+    # Exact/close mapping
+    'eng': 'eng_Latn',
+    'lug': 'lug_Latn',
+    'ach': 'luo_Latn',
+    'ibo': 'ibo_Latn',
+    'swa': 'swh_Latn',
+    # Overwrite unused language tokens
+    'nyn': 'ace_Latn',
+    'teo': 'afr_Latn',
+    'lgg': 'aka_Latn',
+}

--- a/constants.py
+++ b/constants.py
@@ -23,13 +23,13 @@ SALT_LANGUAGE_TOKENS_WHISPER = {
 
 SALT_LANGUAGE_TOKENS_NLLB_TRANSLATION = {
     # Exact/close mapping
-    'eng': 'eng_Latn',
-    'lug': 'lug_Latn',
-    'ach': 'luo_Latn',
-    'ibo': 'ibo_Latn',
-    'swa': 'swh_Latn',
+    'eng': 256047, # eng_Latn
+    'lug': 256110, # lug_Latn
+    'ach': 256111, # luo_Latn
+    'ibo': 256073, # ibo_Latn
+    'swa': 256168, # swh_Latn
     # Overwrite unused language tokens
-    'nyn': 'ace_Latn',
-    'teo': 'afr_Latn',
-    'lgg': 'aka_Latn',
+    'nyn': 256002,
+    'teo': 256006,
+    'lgg': 256008,
 }

--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,14 @@
+SALT_LANGUAGE_NAMES = {
+    'ach': 'Acholi',
+    'eng': 'English,
+    'ibo': 'Igbo',
+    'lgg': 'Lugbara',
+    'lug': 'Luganda',
+    'nyn': 'Runyankole',
+    'swa': 'Swahili',
+    'teo': 'Ateso',
+}
+
 SALT_LANGUAGE_TOKENS_WHISPER = {
     # Exact/close mapping
     'eng': 50259,


### PR DESCRIPTION
This PR adds a file with constants, currently language names and token mappings, which can be referred to during training and inference. Currently these are separately redefined in different pieces of code (training notebooks and inference), but it would be better to make sure everything stays in sync by referring to the same definition, e.g. `language_id_tokens = salt.constants.SALT_LANGUAGE_TOKENS_WHISPER`.